### PR TITLE
Fix for setChannel

### DIFF
--- a/HC4051.h
+++ b/HC4051.h
@@ -57,8 +57,9 @@ public:
         //  only write changed pins. //  AVR only?
         if (mask & _changed)
         {
-          digitalWrite(_pins[i--], (mask & _new));
+          digitalWrite(_pins[i], (mask & _new));
         }
+        i--;
         mask >>= 1;
       }
       enable();


### PR DESCRIPTION
As mentioned in Issue #4, this fixes setChannel as it decrements variable i regardless if there is a change or not. I believe this is correct behaviour as without it, the digital pins were not getting set properly.